### PR TITLE
Added "slide" event notification and a function hook "before" to run before any slide action

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,11 +4,39 @@ jQuery/Switch is an iOS-inspired slide/toggle widget. It began as an alternative
 
 This is a fork of https://github.com/rawnet/jquery-switch. Refer to it for more information.
 
-This fork adds a "slide" event notification passing the customized new value when called. So you can get notified by doing this:
+This fork adds a "slide" event notification passing the customized new value after the transition has happened. So you can get notified by doing this:
 
 ```javascript
 something.bind("slide", function(event, slide_val)) {
 	// Do something with slide_val ...
+});
+```
+
+Also there's an option to pass a custom function "before(...)" that is run before any on/off/toggle action.
+Returning false prevents to action while true let the action happen.
+
+before(...) takes 3 arguments:
+- controls: the control object so you can run your own action e.g. control.on()  
+- type: on/off
+- custom_type: the custom values for on/off
+
+```javascript
+$("select").switchify({
+	before: function(controls, type, custom_type) {
+    	// do something asynchronous that has some callbacks for success and/or error for example.
+        _sendMessage({
+			//...
+			success: function() {
+				// Do something custom here, and then call the transition silently so before function is not called.
+            	controls[type]({silent: true});   // like controls.on({silent: true});
+            },
+            error: function(){
+            	// the slider won't move because there was an error. 
+            }
+        });
+        
+		return false;
+    }
 });
 ```
 

--- a/jquery.switch/jquery.switch-0.3.5.js
+++ b/jquery.switch/jquery.switch-0.3.5.js
@@ -101,6 +101,7 @@
         off: opts.filter('[value=' + values.off + ']').text()
       };
       
+      var before = options.before || function(type) {return true;};
       // assign the <select>'s val as a class on the switch
       var $switch = $(template.replace('{{on}}', text.on).replace('{{off}}', text.off));
       $switch.addClass($select.val() == values.on ? 'on' : 'off');
@@ -151,12 +152,28 @@
       
       // add controls to the switch widget
       var controls = $switch.data('controls', {
-        on:  function() { if (!disabled) { $switch.trigger('slide:on');  return $switch; } },
-        off: function() { if (!disabled) { $switch.trigger('slide:off'); return $switch; } },
-        toggle: function() {
-          if (!disabled) {
-            $switch.trigger('slide:' + ($select.val() == values.on ? 'off' : 'on'));
-          }; return $switch;
+        _transition: function(type, options) {
+          if (!disabled) { 
+            options = (typeof(options) !== 'undefined') ? options : {};
+            if (options.hasOwnProperty('silent') && options.silent) {
+              $switch.trigger('slide:' + type);
+            } else {
+              if (before(this, type, values[type])) {
+                $switch.trigger('slide:' + type);
+              }
+            }
+          }
+          return $switch;
+        },
+        on:  function(options) { 
+          return this._transition('on', options);
+        },
+        off: function(options) {
+          return this._transition('off', options);
+        },
+        toggle: function(options) {
+          var v = ($select.val() == values.on ? 'off' : 'on');
+          return this._transition(v, options);
         }
       }) && $switch.data('controls');
       


### PR DESCRIPTION
This adds a "slide" event notification passing the customized new value after the transition has happened. So you can get notified by doing this:

something.bind("slide", function(event, slide_val)) {
    // Do something with slide_val ...
});

Also there's an optional function hook "before(...)" that is run before any on/off/toggle action. Returning false prevents to action while true let the action happen.

before(...) takes 3 arguments: - controls: the control object so you can run your own action e.g. control.on()
- type: on/off - custom_type: the custom values for on/off

$("select").switchify({
    before: function(controls, type, custom_type) {
        // do something asynchronous that has some callbacks for success and/or error for example.
        $.ajax(
            //...
            success: function() {
                // Do something custom here, and then call the transition silently so before function is not called.
                controls[type]({silent: true});   // like controls.on({silent: true});
            },
            error: function(){
                // the slider won't move because there was an error. 
            }
            // ...
        );

```
    return false;
}
```

});
